### PR TITLE
NVM_DIR env needs to be set when installing

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,7 +59,7 @@ class nvm_nodejs (
     user        => $user,
     unless      => "test -e ${home}/.nvm/v${version}/bin/node",
     provider    => shell,
-    environment => [ "HOME=/${home}" ],
+    environment => [ "HOME=/${home}", "NVM_DIR=${home}/.nvm" ],
     refreshonly => true,
   }
 


### PR DESCRIPTION
I found this is necessary to get it working properly on ubuntu
