### PR TITLE
Update nvm install script to use the one from githubusercontent.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@ class nvm_nodejs (
 
   # install via script
   exec { 'nvm-install-script':
-    command     => 'curl https://raw.github.com/creationix/nvm/master/install.sh | sh',
+    command     => 'curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | sh',
     cwd         => $home,
     user        => $user,
     creates     => "${home}/.nvm/nvm.sh",


### PR DESCRIPTION
Currently when installing nvm, `curl https://raw.github.com/creationix/nvm/master/install.sh` is used. However, github now redirects raw files to raw.githubusercontent.com, and the curl command does not follow the redirect, which makes the download of the nvm install script fails.

I found there are some other projects having the same issue, and the simplest solution is changing the github.com to githubusercontent.com.

For example:
https://github.com/pote/gpm/issues/30
https://github.com/prose/prose/issues/697
