### PR TITLE
Use dot operator

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,12 +54,12 @@ class nvm_nodejs (
   }
 
   exec { 'nvm-install-node':
-    command     => "source ${home}/.nvm/nvm.sh && nvm install ${version}",
+    command     => ". ${home}/.nvm/nvm.sh && nvm install ${version}",
     cwd         => $home,
     user        => $user,
     unless      => "test -e ${home}/.nvm/v${version}/bin/node",
     provider    => shell,
-    environment => [ "HOME=/${home}", "NVM_DIR=${home}/.nvm" ],
+    environment => [ "HOME=${home}", "NVM_DIR=${home}/.nvm" ],
     refreshonly => true,
   }
 


### PR DESCRIPTION
This fixes #8, and is supported by most shells (whereas `source` is a bash thing).
